### PR TITLE
Use pkg-config on non-windows platforms before resording to LD_LIBRARY_PATH

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,9 @@ dynamic_link = []
 [build-dependencies]
 bindgen = { version = "0.49", optional = true }
 
+[target.'cfg(not(windows))'.build-dependencies]
+pkg-config = { version = "0.3" }
+
 [dependencies]
 libc = "0.2"
 


### PR DESCRIPTION
I also added the ability to specify the path to the SDL2 lib directly as an env var.