### PR TITLE
Several changes (was planning on being a long lived branch)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ cmake = "0.1"
 # Enable this to dynamicly link to SDL2. The default is to static link because
 # even with a staticly linked SDL2 the end user can override the SDL2 used at
 # runtime (if absolutely necessary) via SDL2's "Dynamic API" system.
-# https://sdl-mirror.readthedocs.io/en/latest/README-dynapi.html 
+# https://sdl-mirror.readthedocs.io/en/latest/README-dynapi.html
 #
 # WARNING: THIS DOES NOT WORK ON UNIX SYSTEMS. If you'd like it to work on unix
 # systems please submit the PR to fix the build/link process, because I don't
@@ -41,6 +41,20 @@ cargo_check = []
 # Not Part Of Semver! With this on, the x86_64-pc-windows-msvc target will build
 # much faster. No effect on other targets.
 experimental_fast_build = ["dynamic_link"]
+
+# Requires Nightly! Unstable! Use `#[link_args]` for `weak_framework` support on
+# macOS (specifically, do this for `GameController.framework` and
+# `CoreHaptic.framework` if they're linked in, since they're so new)
+nightly_macos_link_args = []
+
+# Use the `sdl2-config` binary that's either on the path, or specified via the
+# `FERMIUM_SDL2_CONFIG_PATH` environment variable. If not specified in the
+# environment, then we require it be at least the version we'd bundle.
+# Otherwise, you should set `FERMIUM_ALLOW_OLDER=1` in the environment.
+#
+# If no binary is set, we fall back to building and linking our bundled version
+# unless `FERMIUM_NO_CMAKE_FALLBACK=1` is set.
+use_sdl2_config = []
 
 [package.metadata.docs.rs]
 # building the docs is a "check only" style operation.

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,256 @@
-use std::env;
+use std::{env, path::PathBuf};
+
+fn cmake_build(cfg: &CargoCfg) -> PathBuf {
+  let mut cm = cmake::Config::new(cfg.manifest_dir.join("SDL2-2.0.14"));
+  cm.static_crt(true);
+  cm.target(&cfg.target);
+  // FERMIUM_NATIVE_OUT_DIR should be something like
+  // `/path/to/your_project/.native_build`
+  let shared_output = if let Some(o) = user_env("FERMIUM_NATIVE_OUT_DIR") {
+    let path = PathBuf::from(o);
+    assert!(
+      path.is_absolute(),
+      "FERMIUM_NATIVE_OUT_DIR must be an absolute path, got: {}",
+      path.display()
+    );
+    let out = path.join(&cfg.target).join("fermium").join("SDL2-2.0.14");
+    cm.out_dir(&out);
+    true
+  } else {
+    false
+  };
+
+  let off_unless_shared = if shared_output { "ON" } else { "OFF" };
+  if cfg.feat_dynamic_link {
+    cm.define("SDL_SHARED", "ON");
+    cm.define("SDL_STATIC", off_unless_shared);
+  } else {
+    cm.define("SDL_SHARED", off_unless_shared);
+    cm.define("SDL_STATIC", "ON");
+    // windows-gnu targets don't use PIC
+    if !cfg.target.contains("windows-gnu") {
+      cm.define("SDL_STATIC_PIC", "ON");
+    }
+  }
+
+  // Allow overriding the CMake generator (e.g. `Ninja` is generally the fastest
+  // if set up, but it generally isn't set up, so CMake won't use it — define
+  // `FERMIUM_CMAKE_GENERATOR="Ninja"` if you know you it should work for you)
+  match (user_env_flag("FERMIUM_USE_NINJA"), have_ninja()) {
+    // If nothing is specified, treat it as "auto", e.g. use if present (it's
+    // *substantially* faster, bringing the time for building the C code to
+    // ~17s — this doesn't count `cmake` configure time, sadly)
+    (None, true) | (Some(true), true) => {
+      cm.generator("Ninja");
+    }
+    (Some(true), false) => {
+      // We could panic... but lets just let cmake trigger the error, in case it
+      // manages to find it or something. Just warn, although they probably
+      // won't see it.
+      println!(
+        "cargo:warning=`FERMIUM_USE_NINJA=1` is specified in the \
+         environment, but ninja doesn't seem to be installed",
+      );
+      cm.generator("Ninja");
+    }
+    // Not installed, not requested, explicitly disabled...
+    _ => {}
+  }
+
+  // cm.always_configure(false);
+  cm.profile("Release");
+
+  let build_output_path = cm.build();
+  println!("build_output_path: {}", build_output_path.display());
+  build_output_path
+}
+
+fn have_ninja() -> bool {
+  have_exe("ninja") || have_exe("ninja-build")
+}
+
+fn windows_link(dynamic: bool) {
+  if dynamic {
+    println!("cargo:rustc-link-lib=SDL2");
+  } else {
+    println!("cargo:rustc-link-lib=static=SDL2-static");
+    println!("cargo:rustc-link-lib=user32");
+    println!("cargo:rustc-link-lib=gdi32");
+    println!("cargo:rustc-link-lib=winmm");
+    println!("cargo:rustc-link-lib=imm32");
+    println!("cargo:rustc-link-lib=ole32");
+    println!("cargo:rustc-link-lib=oleaut32");
+    println!("cargo:rustc-link-lib=version");
+    println!("cargo:rustc-link-lib=uuid");
+    println!("cargo:rustc-link-lib=advapi32");
+    println!("cargo:rustc-link-lib=setupapi");
+    println!("cargo:rustc-link-lib=shell32");
+  }
+}
+
+fn unix_link(cfg: &CargoCfg, static_libs: bool, sdl_config_stdout: &str) {
+  for term in sdl_config_stdout.split_whitespace() {
+    if term.starts_with("-L") {
+      println!("cargo:rustc-link-search=native={}", &term[2..]);
+    } else if term.starts_with("-lSDL2") {
+      if static_libs {
+        println!("cargo:rustc-link-lib=SDL2");
+      } else {
+        println!("cargo:rustc-link-lib=static=SDL2");
+      }
+    } else if term.starts_with("-l") {
+      // normal link
+      if term.ends_with(".framework") {
+        // macOS framework link, weirdly through -l. It's a bug that this
+        // happens: https://github.com/libsdl-org/SDL/issues/4181
+        let name_framework = term.rsplit("/").next().unwrap();
+        let name = name_framework.split(".").next().unwrap();
+        println!("cargo:rustc-link-lib=framework={}", name);
+      } else {
+        println!("cargo:rustc-link-lib={}", &term[2..]);
+      }
+    } else if term.starts_with("-Wl,-framework,") {
+      // macOS framework link
+      println!("cargo:rustc-link-lib=framework={}", &term[15..]);
+    } else if term.starts_with("-Wl,-weak_framework,") {
+      // rust doesn't seem to have "weak" framework linking so we just
+      // declare a normal framework link, but let the user opt into an
+      // unstable feature where we try to force it. FIXME: does this work?
+
+      // TODO(thom): Ideally we should handle GameController/CoreHaptics
+      // differently from Metal/QuartzCore here, since the latter is so much
+      // more widely supported. TODO: exclusions should be an env param.
+      let lib = &term[20..];
+      if cfg.feat_nightly_macos_link_args
+        && !matches!(lib, "Metal" | "QuartzCore")
+      {
+        match lib {
+          "GameController" => {
+            println!("cargo:rustc-cfg=weak_framework_game_controller");
+          }
+          "CoreHaptics" => {
+            println!("cargo:rustc-cfg=weak_framework_core_haptics");
+          }
+          // "Metal" => {
+          //   println!("cargo:rustc-cfg=weak_framework_metal");
+          // }
+          // "QuartzCore" => {
+          //   println!("cargo:rustc-cfg=weak_framework_quartz_core");
+          // }
+          lib => {
+            panic!("Unknown weak_framework: {}", lib);
+          }
+        }
+      } else {
+        // Didn't opt in to unstable, or it's commen enough not to be worth
+        // it, do a strong link.
+        println!("cargo:rustc-link-lib=framework={}", lib);
+      }
+    } else if false
+    /* && term.starts_with("-Wl,-rpath,") */
+    {
+      // I don't know why this works, but it does seem to?
+
+      // IMPORTANT(thom): depending on what this path is, it will make
+      // binaries non-portable! It may even prevent them from working
+      // outside of `cargo run`! Remember to come back to this.
+      // (in case I forget to search for IMPORTANT: TODO, FIXME)
+      println!("cargo:rustc-env=DYLD_LIBRARY_PATH={}", &term[11..]);
+    } else if term.starts_with("-Wl,--enable-new-dtags") {
+      // Nothing
+    } else if term.starts_with("-Wl,--no-undefined") {
+      // Nothing
+    } else if term.starts_with("-pthread") {
+      // Nothing special on the Rust side, I'm told.
+    } else if term.starts_with("-Wl,-current_version,") {
+      // It's a bug we get these: https://github.com/libsdl-org/SDL/issues/4181
+    } else if term.starts_with("-Wl,-compatibility_version,") {
+      // It's a bug we get these: (see above)
+    } else if term.starts_with("-Wl,-undefined,error") {
+      // It's a bug we get these: (see above)
+    } else {
+      panic!("Unknown term: >>{}<<", term);
+    }
+  }
+}
+
+fn link_sdl2_using_config(cfg: &CargoCfg, cmd: &std::path::Path) {
+  let link_style_arg: &str =
+    if cfg.feat_dynamic_link { "--libs" } else { "--static-libs" };
+  let sd2_config_linking = std::process::Command::new(cmd)
+    .arg(link_style_arg)
+    .output()
+    .unwrap_or_else(|_| {
+      panic!("Couldn't run `{} {}`.", cmd.display(), link_style_arg)
+    });
+  let stdout = String::from_utf8_lossy(&sd2_config_linking.stdout);
+  let stderr = String::from_utf8_lossy(&sd2_config_linking.stderr);
+  println!("`{} {}` stdout: {:?}", cmd.display(), link_style_arg, stdout);
+  println!("`{} {}` stderr: {:?}", cmd.display(), link_style_arg, stderr);
+  println!(
+    "`{} {}` status: {:?}",
+    cmd.display(),
+    link_style_arg,
+    sd2_config_linking.status,
+  );
+  assert!(sd2_config_linking.status.success());
+  assert!(!cfg.is_windows, "sdl2-config on windows? {:?}", &stdout);
+  assert!(
+    cfg.is_unix,
+    "Everything that isn't windows is unix. (target = {:?})",
+    cfg.target
+  );
+  unix_link(cfg, cfg.feat_dynamic_link, stdout.trim());
+}
+
+fn sdl2_config_version_check(cmd: &str) -> bool {
+  if let Some(true) = user_env_flag("FERMIUM_ALLOW_OLDER") {
+    return true;
+  }
+  let ver = std::process::Command::new(cmd)
+    .arg("--version")
+    .output()
+    .expect("sdl2-config failed");
+  let stdout = String::from_utf8_lossy(&ver.stdout);
+  let stderr = String::from_utf8_lossy(&ver.stderr);
+  println!("`sdl2-config --version` stdout: {:?}", stdout);
+  println!("`sdl2-config --version` stderr: {:?}", stderr);
+  println!("`sdl2-config --version` status: {:?}", ver.status);
+  if !ver.status.success() {
+    println!(
+      "cargo:warning=`sdl2-config --version` failed with: {:?}",
+      ver.status.code()
+    );
+    return false;
+  }
+  return if let Some(semver) = hacky_parse_semver(&stdout) {
+    let result = semver >= (2, 0, 14);
+    println!("determined version: {:?}. good enough? {:?}", semver, result);
+    result
+  } else {
+    println!(
+      "cargo:warning=Failed to parse `sdl2-config --version` output: {:?}",
+      stdout
+    );
+    false
+  };
+  fn hacky_parse_semver(version: &str) -> Option<(u64, u64, u64)> {
+    let version = version.trim();
+    let vals = version
+      .find(|c| c == '-' || c == '+')
+      .map(|v| &version[..v])
+      .unwrap_or(version);
+    let res = vals
+      .split('.')
+      .map(|v| v.trim().parse::<u64>())
+      .collect::<Result<Vec<_>, _>>();
+    if let Ok(&[maj, min, patch, ..]) = res.as_deref() {
+      Some((maj, min, patch))
+    } else {
+      None
+    }
+  }
+}
 
 fn main() {
   // Note(Lokathor): I was told by thomcc@github to put this in because it makes
@@ -9,148 +261,153 @@ fn main() {
   // This won't affect our ability to develop the Rust level bindings.
   println!("cargo:rerun-if-changed=build.rs");
 
-  let target = env::var("TARGET").expect("Could not read `TARGET`!");
-  println!("target:{}", target);
+  let config = CargoCfg::get();
 
-  let out_dir = env::var("OUT_DIR").expect("Could not read `OUT_DIR`!");
-  println!("out_dir:{}", out_dir);
+  // Copy the DLL for loka's binary.
+  if config.is_windows {
+    println!("cargo:rerun-if-changed=SDL2.dll");
+    let dll_from = config.manifest_dir.join("SDL2.dll");
+    println!("dll_from:{}", dll_from.display());
+    let dll_to = config.out_dir.join("SDL2.dll");
+    println!("dll_to:{}", dll_to.display());
+    std::fs::copy(dll_from, dll_to)
+      .expect("Failed to copy DLL for fermium binary");
+  }
 
-  let cargo_manifest_dir = env::var("CARGO_MANIFEST_DIR")
-    .expect("Could not read `CARGO_MANIFEST_DIR`!");
-  println!("cargo_manifest_dir:{}", cargo_manifest_dir);
-
-  let dll_from = std::path::Path::new(&cargo_manifest_dir).join("SDL2.dll");
-  println!("dll_from:{}", dll_from.display());
-
-  let dll_to = std::path::Path::new(&out_dir).join("SDL2.dll");
-  println!("dll_to:{}", dll_to.display());
-
-  std::fs::copy(dll_from, dll_to).unwrap();
-
-  if cfg!(feature = "experimental_fast_build")
-    && target == "x86_64-pc-windows-msvc"
+  // run the experimental-fast-build feature
+  // TODO(thom): set up for x86_64-apple-darwin?
+  if config.feat_experimental_fast_build
+    && config.target == "x86_64-pc-windows-msvc"
   {
-    let manifest_dir = std::path::PathBuf::from(
-      env::var("CARGO_MANIFEST_DIR")
-        .expect("Could not read `CARGO_MANIFEST_DIR`!"),
-    );
-    // declare search path
+    println!("cargo:rerun-if-changed=SDL2-2.0.14-devel");
+    // declare search path. This doesn't need to be absolute, but *shrug*.
     println!(
       "cargo:rustc-link-search={}",
-      manifest_dir
+      config
+        .manifest_dir
         .join("SDL2-2.0.14-devel")
         .join("x86_64-pc-windows-msvc")
         .display()
     );
     // declare linking (the bundled files only work with dynamic linking)
-    assert!(cfg!(feature = "dynamic_link"));
+    assert!(config.feat_dynamic_link);
     println!("cargo:rustc-link-lib=SDL2");
-  } else if cfg!(not(feature = "cargo_check")) {
-    let manifest_dir = std::path::PathBuf::from(
-      env::var("CARGO_MANIFEST_DIR")
-        .expect("Could not read `CARGO_MANIFEST_DIR`!"),
-    );
-
-    let mut cm = cmake::Config::new(manifest_dir.join("SDL2-2.0.14"));
-    cm.static_crt(true);
-    cm.target(&env::var("TARGET").expect("Couldn't read `TARGET`"));
-    cm.define("SDL_SHARED", "ON");
-    cm.define("SDL_STATIC", "ON");
-    cm.profile("Release");
-    let build_output_path = cm.build();
-    println!("build_output_path: {}", build_output_path.display());
-
-    println!(
-      "cargo:rustc-link-search={}",
-      build_output_path.join("lib").display()
-    );
-
-    if cfg!(windows) {
-      if cfg!(feature = "dynamic_link") {
-        println!("cargo:rustc-link-lib=SDL2");
-      } else {
-        println!("cargo:rustc-link-lib=static=SDL2-static");
-        println!("cargo:rustc-link-lib=user32");
-        println!("cargo:rustc-link-lib=gdi32");
-        println!("cargo:rustc-link-lib=winmm");
-        println!("cargo:rustc-link-lib=imm32");
-        println!("cargo:rustc-link-lib=ole32");
-        println!("cargo:rustc-link-lib=oleaut32");
-        println!("cargo:rustc-link-lib=version");
-        println!("cargo:rustc-link-lib=uuid");
-        println!("cargo:rustc-link-lib=advapi32");
-        println!("cargo:rustc-link-lib=setupapi");
-        println!("cargo:rustc-link-lib=shell32");
-      }
-    } else if cfg!(unix) {
-      let sdl2_cfg_cmd = format!(
-        "{}",
-        build_output_path.join("bin").join("sdl2-config").display()
+    return;
+  }
+  if config.feat_cargo_check {
+    return;
+  }
+  if config.feat_use_sdl2_config && !config.feat_use_sdl2_config {
+    if let Some(p) = user_env("FERMIUM_SDL2_CONFIG_PATH") {
+      // If the path is explicitly specified via the environment, use it without
+      // bothering to check the version.
+      return link_sdl2_using_config(&config, p.as_ref());
+    } else if have_exe("sdl2-config")
+      && sdl2_config_version_check("sdl2-config")
+    {
+      return link_sdl2_using_config(&config, "sdl2-config".as_ref());
+    } else if user_env_flag("FERMIUM_NO_CMAKE_FALLBACK").unwrap_or(false) {
+      panic!(
+        "Failed to locate an up to date `sdl2-config`. Ensure it's at least version 2.0.14, \
+         or alternatively set `FERMIUM_ALLOW_OLDER=1` variable in the environment."
       );
-      // Call sdl2-config and do what it says to do.
-      let link_style_arg: &str =
-        if cfg!(feature = "dynamic_link") { "--libs" } else { "--static-libs" };
-      let sd2_config_linking = std::process::Command::new(sdl2_cfg_cmd)
-        .arg(link_style_arg)
-        .output()
-        .unwrap_or_else(|_| {
-          panic!("Couldn't run `sdl2-config {}`.", link_style_arg)
-        });
-      assert!(sd2_config_linking.status.success());
-
-      let sd2_config_linking_stdout: String =
-        String::from_utf8_lossy(&sd2_config_linking.stdout).into_owned();
-      println!("sd2_config_linking_stdout: {}", sd2_config_linking_stdout);
-      assert!(sd2_config_linking_stdout.len() > 0);
-
-      for term in sd2_config_linking_stdout.split_whitespace() {
-        if term.starts_with("-L") {
-          println!("cargo:rustc-link-search=native={}", &term[2..]);
-        } else if term.starts_with("-lSDL2") {
-          if cfg!(feature = "dynamic_link") {
-            println!("cargo:rustc-link-lib=SDL2")
-          } else {
-            println!("cargo:rustc-link-lib=static=SDL2")
-          };
-        } else if term.starts_with("-l") {
-          // normal link
-          if term.ends_with(".framework") {
-            // macOS framework link, weirdly through -l
-            let name_framework = term.rsplit("/").next().unwrap();
-            let name = name_framework.split(".").next().unwrap();
-            println!("cargo:rustc-link-lib=framework={}", name);
-          } else {
-            println!("cargo:rustc-link-lib={}", &term[2..]);
-          }
-        } else if term.starts_with("-Wl,-framework,") {
-          // macOS framework link
-          println!("cargo:rustc-link-lib=framework={}", &term[15..]);
-        } else if term.starts_with("-Wl,-weak_framework,") {
-          // rust doesn't seem to have "weak" framework linking so we just
-          // declare a normal framework link.
-          println!("cargo:rustc-link-lib=framework={}", &term[20..]);
-        } else if term.starts_with("-Wl,-rpath,") {
-          // I don't know why this works, but it does seem to?
-          println!("cargo:rustc-env=DYLD_LIBRARY_PATH={}", &term[11..]);
-        } else if term.starts_with("-Wl,--enable-new-dtags") {
-          // Do we do anything here?
-        } else if term.starts_with("-Wl,--no-undefined") {
-          // Do we do anything here?
-        } else if term.starts_with("-pthread") {
-          // Nothing special on the Rust side, I'm told.
-        } else if term.starts_with("-Wl,-current_version,") {
-          // I don't think rust passes along a current version number?
-        } else if term.starts_with("-Wl,-compatibility_version,") {
-          // I don't think rust passes along a compatibility version number?
-        } else if term.starts_with("-Wl,-undefined,error") {
-          // This asks the linker to error on undefined symbols(?), which it
-          // already will do.
-        } else {
-          panic!("Unknown term: >>{}<<", term);
-        }
-      }
     } else {
-      panic!("Sorry, I only know how to build/link SDL2 on windows and unix.");
+      // fallback to building with `cmake`.
     }
   }
+
+  let build_output_path = cmake_build(&config);
+  println!(
+    "cargo:rustc-link-search={}",
+    build_output_path.join("lib").display()
+  );
+
+  if config.is_windows {
+    windows_link(config.feat_dynamic_link);
+  } else if config.is_unix {
+    let sdl2_cfg_cmd = build_output_path.join("bin").join("sdl2-config");
+    link_sdl2_using_config(&config, &sdl2_cfg_cmd);
+  } else {
+    panic!("Sorry, I only know how to build/link SDL2 on windows and unix.");
+  }
+}
+
+/// Config from cargo, all in one place. For the most part, it's better to keep
+/// user parameters out of this other than features.
+struct CargoCfg {
+  feat_cargo_check: bool,
+  feat_experimental_fast_build: bool,
+  feat_dynamic_link: bool,
+  feat_nightly_macos_link_args: bool,
+  feat_use_sdl2_config: bool,
+  out_dir: PathBuf,
+  manifest_dir: PathBuf,
+  target: String,
+  is_windows: bool,
+  is_unix: bool,
+}
+
+impl CargoCfg {
+  fn get() -> Self {
+    Self {
+      feat_cargo_check: cargo_env_flag("CARGO_FEATURE_CARGO_CHECK"),
+      feat_dynamic_link: cargo_env_flag("CARGO_FEATURE_DYNAMIC_LINK"),
+      feat_experimental_fast_build: cargo_env_flag(
+        "CARGO_FEATURE_EXPERIMENTAL_FAST_BUILD",
+      ),
+      feat_nightly_macos_link_args: cargo_env_flag(
+        "CARGO_FEATURE_NIGHTLY_MACOS_LINK_ARGS",
+      ),
+      feat_use_sdl2_config: cargo_env_flag("CARGO_FEATURE_USE_SDL2_CONFIG"),
+      is_windows: cargo_env_flag("CARGO_CFG_WINDOWS"),
+      is_unix: cargo_env_flag("CARGO_CFG_UNIX"),
+      out_dir: PathBuf::from(cargo_env("OUT_DIR")),
+      manifest_dir: PathBuf::from(
+        cargo_opt_env("CARGO_MANIFEST_DIR").unwrap_or_else(|| ".".into()),
+      ),
+      target: cargo_env("TARGET"),
+    }
+  }
+}
+
+fn have_exe(cmd: &str) -> bool {
+  // Note: In theory we should rerun on change for `PATH`, but in practice it
+  // would be way to high churn.
+  env::split_paths(&env::var_os("PATH").unwrap_or(Default::default()))
+    .find(|p| p.join(cmd).exists())
+    .is_some()
+}
+
+fn user_env(s: &str) -> Option<String> {
+  println!("cargo:rerun-if-env-changed={}", s);
+  env::var(s).ok()
+}
+
+fn user_env_flag(s: &str) -> Option<bool> {
+  match user_env(s).map(|s| s.to_lowercase()).as_deref() {
+    None | Some("") => None,
+    // cmake-alike flags
+    Some("0") | Some("off") | Some("no") | Some("false") => Some(false),
+    Some(_) => Some(true),
+  }
+}
+
+/// Returns the value of `s` in the env, or none.
+fn cargo_opt_env(s: &str) -> Option<String> {
+  let r = env::var(s).ok();
+  println!("env[{:?}] = {:?}", s, r);
+  r
+}
+
+/// Returns the value of `s` in the env, or panics.
+#[track_caller]
+fn cargo_env(s: &str) -> String {
+  cargo_opt_env(s).unwrap_or_else(|| panic!("Environment is missing {:?}", s))
+}
+
+/// Returns `true` if `s` is set in the env.
+fn cargo_env_flag(s: &str) -> bool {
+  let r = env::var_os(s).is_some();
+  println!("env[{:?}] = {:?}", s, r);
+  r
 }

--- a/src/bin/fermium.rs
+++ b/src/bin/fermium.rs
@@ -1,9 +1,8 @@
-use std::io::Write;
-
-const DLL_BYTES: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/SDL2.dll"));
-
 #[cfg(windows)]
 fn main() -> std::io::Result<()> {
+  use std::io::Write;
+  const DLL_BYTES: &[u8] =
+    include_bytes!(concat!(env!("OUT_DIR"), "/SDL2.dll"));
   let mut f = std::fs::File::create("SDL2.dll")?;
   f.write_all(DLL_BYTES)?;
   println!("Successfully wrote out SDL2.dll (x86_64)");

--- a/src/haptic.rs
+++ b/src/haptic.rs
@@ -1,0 +1,819 @@
+//! The SDL haptic subsystem allows you to control haptic (force feedback)
+//! devices.
+use crate::prelude::*;
+
+/// The opaque haptic structure used to identify an SDL haptic device.
+#[repr(transparent)]
+pub struct SDL_Haptic(c_void);
+/// Haptic effect type.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(transparent)]
+pub struct SDL_HapticEffectType(pub u16);
+
+impl SDL_HapticEffectType {
+  /// Convert a [`SDL_HapticEffectType`] into a [`SDL_HapticFeatures`]
+  /// indicating support for the effect type.
+  #[inline]
+  pub const fn feature(self) -> SDL_HapticFeatures {
+    SDL_HapticFeatures(self.0 as u32)
+  }
+}
+/// Constant haptic effect.
+///
+/// Used with [`SDL_HapticConstant`].
+pub const SDL_HAPTIC_CONSTANT: SDL_HapticEffectType =
+  SDL_HapticEffectType(1 << 0);
+/// Sine wave haptic effect.
+///
+/// Periodic haptic effect that simulates sine waves.
+///
+/// Used with [`SDL_HapticPeriodic`].
+pub const SDL_HAPTIC_SINE: SDL_HapticEffectType = SDL_HapticEffectType(1 << 1);
+/// Left/Right haptic effect.
+///
+/// Haptic effect for direct control over high/low frequency motors.
+///
+/// Used with [`SDL_HapticLeftRight`].
+pub const SDL_HAPTIC_LEFTRIGHT: SDL_HapticEffectType =
+  SDL_HapticEffectType(1 << 2);
+/// Triangle wave haptic effect.
+///
+/// Periodic haptic effect that simulates triangular waves.
+///
+/// Used with [`SDL_HapticPeriodic`].
+pub const SDL_HAPTIC_TRIANGLE: SDL_HapticEffectType =
+  SDL_HapticEffectType(1 << 3);
+/// "Sawtoothup" wave haptic effect.
+///
+/// Periodic haptic effect that simulates saw tooth up waves.
+///
+/// Used with [`SDL_HapticPeriodic`].
+pub const SDL_HAPTIC_SAWTOOTHUP: SDL_HapticEffectType =
+  SDL_HapticEffectType(1 << 4);
+/// "Sawtoothdown" wave haptic effect.
+///
+/// Periodic haptic effect that simulates saw tooth down waves.
+///
+/// Used with [`SDL_HapticPeriodic`].
+pub const SDL_HAPTIC_SAWTOOTHDOWN: SDL_HapticEffectType =
+  SDL_HapticEffectType(1 << 5);
+/// Ramp haptic effect.
+///
+/// Used with [`SDL_HapticRamp`].
+pub const SDL_HAPTIC_RAMP: SDL_HapticEffectType = SDL_HapticEffectType(1 << 6);
+
+/// Spring effect - uses axes position.
+///
+/// Condition haptic effect that simulates a spring.  Effect is based on the
+/// axes position.
+///
+/// Used with [`SDL_HapticCondition`].
+pub const SDL_HAPTIC_SPRING: SDL_HapticEffectType =
+  SDL_HapticEffectType(1 << 7);
+/// Damper effect - uses axes velocity.
+///
+/// Condition haptic effect that simulates dampening.  Effect is based on the
+/// axes velocity.
+///
+/// Used with [`SDL_HapticCondition`].
+pub const SDL_HAPTIC_DAMPER: SDL_HapticEffectType =
+  SDL_HapticEffectType(1 << 8);
+/// Inertia effect - uses axes acceleration.
+///
+/// Condition haptic effect that simulates inertia.  Effect is based on the axes
+/// acceleration.
+///
+/// Used with [`SDL_HapticCondition`].
+pub const SDL_HAPTIC_INERTIA: SDL_HapticEffectType =
+  SDL_HapticEffectType(1 << 9);
+
+/// Friction effect - uses axes movement.
+///
+/// Condition haptic effect that simulates friction.  Effect is based on the
+/// axes movement.
+///
+/// Used with [`SDL_HapticCondition`].
+pub const SDL_HAPTIC_FRICTION: SDL_HapticEffectType =
+  SDL_HapticEffectType(1 << 10);
+
+/// User defined custom haptic effect.
+///
+/// Used with [`SDL_HapticCustom`].
+pub const SDL_HAPTIC_CUSTOM: SDL_HapticEffectType =
+  SDL_HapticEffectType(1 << 11);
+
+/// Represents a bitmask of features which are potentially supported by a haptic
+/// device. Used with [`SDL_HapticQuery`].
+///
+/// Each of the [`SDL_HapticEffectType`] values can be converted into a
+/// [`SDL_HapticFeatures`] that indicates if the device supports use of that
+/// effect type using the [`SDL_HapticEffectType::features`] method.
+///
+/// Tests can be performed in various ways, for example:
+/// ```text
+/// let want = SDL_HAPTIC_CONSTANT.feature() | SDL_HAPTIC_PAUSE;
+/// let have = SDL_HapticQuery(haptic);
+/// if (have & want) == want {
+///     // Device supports the constant haptic effect, and pausing.
+/// }
+/// ```
+///
+/// # Rationale
+///
+/// This type doesn't exist in the C SDL2 headers. Instead, the effect types are
+/// `#define`d constants, which are used either as a feature bitset, or a effect
+/// type constant. This doesn't really work for Rust, especially since these two
+/// uses have different sizes. As a result, we provide separate types for
+/// `SDL_HapticFeatures` (used with [`SDL_HapticQuery`]), and
+/// [`SDL_HapticEffectType`] (used with most of the other haptics APIs).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(transparent)]
+pub struct SDL_HapticFeatures(pub u32);
+impl_bit_ops_for_tuple_newtype!(SDL_HapticFeatures);
+
+/// Haptic device supports global gain.
+///
+/// Used to test the result of [`SDL_HapticQuery`] to determine if the device
+/// supports [`SDL_HapticSetGain`], etc.
+pub const SDL_HAPTIC_GAIN: SDL_HapticFeatures = SDL_HapticFeatures(1 << 12);
+
+/// Haptic device supports setting autocenter.
+///
+/// Used to test the result of [`SDL_HapticQuery`] to determine if the device
+/// supports [`SDL_HapticSetAutocenter`], etc.
+pub const SDL_HAPTIC_AUTOCENTER: SDL_HapticFeatures =
+  SDL_HapticFeatures(1 << 13);
+/// Haptic device supports querying effect status.
+///
+/// Used to test the result of [`SDL_HapticQuery`] to determine if the device
+/// supports [`SDL_HapticGetEffectStatus`], etc.
+pub const SDL_HAPTIC_STATUS: SDL_HapticFeatures = SDL_HapticFeatures(1 << 14);
+
+/// Haptic device supports being paused.
+///
+/// Used to test the result of [`SDL_HapticQuery`] to determine if the device
+/// supports [`SDL_HapticPause`], [`SDL_HapticUnpause`], etc.
+pub const SDL_HAPTIC_PAUSE: SDL_HapticFeatures = SDL_HapticFeatures(1 << 15);
+
+/// Used to play a device an infinite number of times.
+///
+/// See [`SDL_HapticRunEffect`].
+pub const SDL_HAPTIC_INFINITY: u32 = 4294967295u32;
+
+/// A type used with [`SDL_HapticDirection`]. One of
+/// - [`SDL_HAPTIC_POLAR`]
+/// - [`SDL_HAPTIC_CARTESIAN`]
+/// - [`SDL_HAPTIC_SPHERICAL`]
+/// - [`SDL_HAPTIC_STEERING_AXIS`]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(transparent)]
+pub struct SDL_HapticDirectionType(pub u8);
+
+/// Uses polar coordinates for the direction in [`SDL_HapticDirection`].
+pub const SDL_HAPTIC_POLAR: SDL_HapticDirectionType =
+  SDL_HapticDirectionType(0);
+/// Uses cartesian coordinates for the direction in [`SDL_HapticDirection`].
+pub const SDL_HAPTIC_CARTESIAN: SDL_HapticDirectionType =
+  SDL_HapticDirectionType(1);
+/// Uses spherical coordinates for the direction in [`SDL_HapticDirection`].
+pub const SDL_HAPTIC_SPHERICAL: SDL_HapticDirectionType =
+  SDL_HapticDirectionType(2);
+/// Use this value to play an effect on the steering wheel axis. This provides
+/// better compatibility across platforms and devices as SDL will guess the
+/// correct axis.
+pub const SDL_HAPTIC_STEERING_AXIS: SDL_HapticDirectionType =
+  SDL_HapticDirectionType(3);
+
+/// Structure that represents a haptic direction.
+///
+/// This is the direction where the force comes from, instead of the direction
+/// in which the force is exerted.
+///
+/// Cardinal directions of the haptic device are relative to the positioning of
+/// the device.  North is considered to be away from the user.
+///
+/// See <https://wiki.libsdl.org/SDL_HapticDirection> for detailed diagrams
+/// explaining this type.
+///
+/// # Interpretation of `dir`
+///
+/// ## [`SDL_HAPTIC_POLAR`]
+/// If type is [`SDL_HAPTIC_POLAR`], direction is encoded by hundredths of a
+/// degree starting north and turning clockwise. [`SDL_HAPTIC_POLAR`] only uses
+/// the first `dir` parameter.  The cardinal directions would be:
+/// - North: 0 (0 degrees)
+/// - East: 9000 (90 degrees)
+/// - South: 18000 (180 degrees)
+/// - West: 27000 (270 degrees)
+///
+/// ## [`SDL_HAPTIC_CARTESIAN`]
+/// If type is [`SDL_HAPTIC_CARTESIAN`], direction is encoded by three positions
+/// (X axis, Y axis and Z axis (with 3 axes)).  [`SDL_HAPTIC_CARTESIAN`] uses
+/// the first three `dir` parameters.  The cardinal directions would be:
+/// - North:  0,-1, 0
+/// - East:   1, 0, 0
+/// - South:  0, 1, 0
+/// - West:  -1, 0, 0
+///
+/// The Z axis represents the height of the effect if supported, otherwise it's
+/// unused.  In cartesian encoding (1, 2) would be the same as (2, 4), you can
+/// use any multiple you want, only the direction matters.
+///
+/// ## [`SDL_HAPTIC_SPHERICAL`]
+/// If type is [`SDL_HAPTIC_SPHERICAL`], direction is encoded by two rotations.
+/// The first two `dir` parameters are used.  The `dir` parameters are as
+/// follows (all values are in hundredths of degrees):
+/// - Degrees from (1, 0) rotated towards (0, 1).
+/// - Degrees towards (0, 0, 1) (device needs at least 3 axes).
+///
+/// ## [`SDL_HAPTIC_STEERING_AXIS`]
+/// This is new in SDL 2.0.14, and is not yet well documented, but as far as I
+/// can tell, all of the fields of `dir` are ignored when this is in use, and it
+/// computes the direction entirely based on the steering wheel.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct SDL_HapticDirection {
+  /// The type of encoding.
+  pub type_: SDL_HapticDirectionType,
+  /// The encoded direction.
+  pub dir: [Sint32; 3],
+}
+
+/// A structure containing a template for a Constant effect.
+///
+/// This struct is exclusively for the [`SDL_HAPTIC_CONSTANT`] effect.
+///
+/// A constant effect applies a constant force in the specified direction
+/// to the joystick.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SDL_HapticConstant {
+  /// Must be [`SDL_HAPTIC_CONSTANT`].
+  pub type_: SDL_HapticEffectType,
+  /// Direction of the effect
+  pub direction: SDL_HapticDirection,
+
+  /* Replay */
+  /// Duration of the effect
+  pub length: Uint32,
+  /// Delay before starting the effect.
+  pub delay: Uint16,
+
+  /* Trigger */
+  /// Button that triggers the effect.
+  pub button: Uint16,
+  /// How soon it can be triggered again after button.
+  pub interval: Uint16,
+
+  /* Constant */
+  /// Strength of the constant effect.
+  pub level: Sint16,
+
+  /* Envelope */
+  /// Duration of the attack.
+  pub attack_length: Uint16,
+  /// Level at the start of the attack.
+  pub attack_level: Uint16,
+  /// Duration of the fade.
+  pub fade_length: Uint16,
+  /// Level at the end of the fade.
+  pub fade_level: Uint16,
+}
+
+/// A structure containing a template for a Periodic effect.
+///
+/// The struct handles the following effects:
+/// - [`SDL_HAPTIC_SINE`]
+/// - [`SDL_HAPTIC_TRIANGLE`]
+/// - [`SDL_HAPTIC_SAWTOOTHUP`]
+/// - [`SDL_HAPTIC_SAWTOOTHDOWN`]
+///
+/// A periodic effect consists in a wave-shaped effect that repeats itself over
+/// time.  The type determines the shape of the wave and the parameters
+/// determine the dimensions of the wave.
+///
+/// Phase is given by hundredth of a degree meaning that giving the phase a
+/// value of 9000 will displace it 25% of its period.  Here are sample values:
+///  - 0: No phase displacement.
+///  - 9000: Displaced 25% of its period.
+///  - 18000: Displaced 50% of its period.
+///  - 27000: Displaced 75% of its period.
+///  - 36000: Displaced 100% of its period, same as 0, but 0 is preferred.
+///
+/// # Caveats
+/// The SDL2 official documentation indicates you can use `SDL_HAPTIC_LEFTRIGHT`
+/// for this structure, however from reading over the source, it is clear that
+/// this is stale information from whien this constant referred to
+/// `SDL_HAPTIC_SQUARE`, which no longer exists.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SDL_HapticPeriodic {
+  /// Type of effect, must be one of:
+  /// - [`SDL_HAPTIC_SINE`]
+  /// - [`SDL_HAPTIC_TRIANGLE`]
+  /// - [`SDL_HAPTIC_SAWTOOTHUP`]
+  /// - [`SDL_HAPTIC_SAWTOOTHDOWN`]
+  pub type_: SDL_HapticEffectType,
+  /// Direction of the effect
+  pub direction: SDL_HapticDirection,
+
+  /* Replay */
+  /// Duration of the effect
+  pub length: Uint32,
+  /// Delay before starting the effect.
+  pub delay: Uint16,
+
+  /* Trigger */
+  /// Button that triggers the effect.
+  pub button: Uint16,
+  /// How soon it can be triggered again after button.
+  pub interval: Uint16,
+
+  /* Periodic */
+  /// Period of the wave.
+  pub period: Uint16,
+  /// Peak value; if negative, equivalent to 180 degrees extra phase shift.
+  pub magnitude: Sint16,
+  /// Mean value of the wave.
+  pub offset: Sint16,
+  /// Positive phase shift given by hundredth of a degree.
+  pub phase: Uint16,
+
+  /* Envelope */
+  /// Duration of the attack.
+  pub attack_length: Uint16,
+  /// Level at the start of the attack.
+  pub attack_level: Uint16,
+  /// Duration of the fade.
+  pub fade_length: Uint16,
+  /// Level at the end of the fade.
+  pub fade_level: Uint16,
+}
+
+/// A structure containing a template for a Condition effect.
+///
+/// The struct handles the following effects:
+/// - [`SDL_HAPTIC_SPRING`]: Effect based on axes position.
+/// - [`SDL_HAPTIC_DAMPER`]: Effect based on axes velocity.
+/// - [`SDL_HAPTIC_INERTIA`]: Effect based on axes acceleration.
+/// - [`SDL_HAPTIC_FRICTION`]: Effect based on axes movement.
+///
+/// Direction is handled by condition internals instead of a direction member.
+/// The condition effect specific members have three parameters.  The first
+/// refers to the X axis, the second refers to the Y axis and the third refers
+/// to the Z axis.  The right terms refer to the positive side of the axis and
+/// the left terms refer to the negative side of the axis.  Please refer to the
+/// [`SDL_HapticDirection`] [diagram][direction-diagram] for which side is
+/// positive and which is negative.
+///
+/// [direction-diagram]: https://wiki.libsdl.org/SDL_HapticDirection#Remarks
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SDL_HapticCondition {
+  /// Type of effect, must be one of:
+  /// - [`SDL_HAPTIC_SPRING`]
+  /// - [`SDL_HAPTIC_DAMPER`]
+  /// - [`SDL_HAPTIC_INERTIA`]
+  /// - [`SDL_HAPTIC_FRICTION`]
+  pub type_: SDL_HapticEffectType,
+  /// Direction of the effect
+  pub direction: SDL_HapticDirection,
+
+  /* Replay */
+  /// Duration of the effect
+  pub length: Uint32,
+  /// Delay before starting the effect.
+  pub delay: Uint16,
+
+  /* Trigger */
+  /// Button that triggers the effect.
+  pub button: Uint16,
+  /// How soon it can be triggered again after button.
+  pub interval: Uint16,
+
+  /* Condition */
+  /// Level when joystick is to the positive side; max 0xFFFF.
+  pub right_sat: [Uint16; 3],
+  /// Level when joystick is to the negative side; max 0xFFFF.
+  pub left_sat: [Uint16; 3],
+  /// How fast to increase the force towards the positive side.
+  pub right_coeff: [Sint16; 3],
+  /// How fast to increase the force towards the negative side.
+  pub left_coeff: [Sint16; 3],
+  /// Size of the dead zone; max 0xFFFF: whole axis-range when 0-centered.
+  pub deadband: [Uint16; 3],
+  /// Position of the dead zone.
+  pub center: [Sint16; 3],
+}
+
+/// A structure containing a template for a Ramp effect.
+///
+/// This struct is exclusively for the [`SDL_HAPTIC_RAMP`] effect.
+///
+/// The ramp effect starts at start strength and ends at end strength.
+/// It augments in linear fashion.  If you use attack and fade with a ramp
+/// the effects get added to the ramp effect making the effect become
+/// quadratic instead of linear.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SDL_HapticRamp {
+  /// Must be [`SDL_HAPTIC_RAMP`].
+  pub type_: SDL_HapticEffectType,
+  /// Direction of the effect.
+  pub direction: SDL_HapticDirection,
+
+  /* Replay */
+  /// Duration of the effect
+  pub length: Uint32,
+  /// Delay before starting the effect.
+  pub delay: Uint16,
+
+  /* Trigger */
+  /// Button that triggers the effect.
+  pub button: Uint16,
+  /// How soon it can be triggered again after button.
+  pub interval: Uint16,
+
+  /* Ramp */
+  /// Beginning strength level.
+  pub start: Sint16,
+  /// Ending strength level.
+  pub end: Sint16,
+
+  /* Envelope */
+  /// Duration of the attack.
+  pub attack_length: Uint16,
+  /// Level at the start of the attack.
+  pub attack_level: Uint16,
+  /// Duration of the fade.
+  pub fade_length: Uint16,
+  /// Level at the end of the fade.
+  pub fade_level: Uint16,
+}
+
+/// A structure containing a template for a Left/Right effect.
+///
+/// This struct is exclusively for the [`SDL_HAPTIC_LEFTRIGHT`] effect.
+///
+/// The Left/Right effect is used to explicitly control the large and small
+/// motors, commonly found in modern game controllers. The small (right) motor
+/// is high frequency, and the large (left) motor is low frequency.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SDL_HapticLeftRight {
+  /// Type of effect, must be [`SDL_HAPTIC_LEFTRIGHT`].
+  pub type_: SDL_HapticEffectType,
+  /* Replay */
+  /// Duration of the effect in milliseconds.
+  pub length: Uint32,
+
+  /* Rumble */
+  /// Control of the large controller motor.
+  pub large_magnitude: Uint16,
+  /// Control of the small controller motor.
+  pub small_magnitude: Uint16,
+}
+
+/// A structure containing a template for the [`SDL_HAPTIC_CUSTOM`] effect.
+///
+/// This struct is exclusively for the [`SDL_HAPTIC_CUSTOM`] effect.
+///
+/// A custom force feedback effect is much like a periodic effect, where the
+/// application can define its exact shape.  You will have to allocate the data
+/// yourself.  Data should consist of channels * samples Uint16 samples.
+///
+/// If channels is one, the effect is rotated using the defined direction.
+/// Otherwise it uses the samples in data for the different axes.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SDL_HapticCustom {
+  /// Type of effect, must be [`SDL_HAPTIC_CUSTOM`].
+  pub type_: SDL_HapticEffectType,
+  /// Direction of the effect
+  pub direction: SDL_HapticDirection,
+
+  /* Replay */
+  /// Duration of the effect
+  pub length: Uint32,
+  /// Delay before starting the effect.
+  pub delay: Uint16,
+
+  /* Trigger */
+  /// Button that triggers the effect.
+  pub button: Uint16,
+  /// How soon it can be triggered again after button.
+  pub interval: Uint16,
+
+  /* Custom */
+  /// Axes to use, minimum of one.
+  pub channels: Uint8,
+  /// Sample periods.
+  pub period: Uint16,
+  /// Amount of samples.
+  pub samples: Uint16,
+  /// Should contain channels*samples items.
+  pub data: *mut Uint16,
+
+  /* Envelope */
+  /// Duration of the attack.
+  pub attack_length: Uint16,
+  /// Level at the start of the attack.
+  pub attack_level: Uint16,
+  /// Duration of the fade.
+  pub fade_length: Uint16,
+  /// Level at the end of the fade.
+  pub fade_level: Uint16,
+}
+
+/// The generic template for any haptic effect.
+///
+/// All values max at 32767 (0x7FFF).  Signed values also can be negative. Time
+/// values unless specified otherwise are in milliseconds.
+///
+/// You can also pass [`SDL_HAPTIC_INFINITY`] to length instead of a 0-32767
+/// value.  Neither delay, interval, attack_length nor fade_length support
+/// [`SDL_HAPTIC_INFINITY`].  Fade will also not be used since effect never
+/// ends.
+///
+/// Additionally, the ::SDL_HAPTIC_RAMP effect does not support a duration of
+/// [`SDL_HAPTIC_INFINITY`].
+///
+/// Button triggers may not be supported on all devices, it is advised to not
+/// use them if possible.  Buttons start at index 1 instead of index 0 like the
+/// joystick.
+///
+/// If both attack_length and fade_level are 0, the envelope is not used,
+/// otherwise both values are used.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub union SDL_HapticEffect {
+  /// Effect type. Always present
+  pub type_: SDL_HapticEffectType,
+  /// Constant effect. Used only when the type is [`SDL_HAPTIC_CONSTANT`].
+  pub constant: SDL_HapticConstant,
+  /// Periodic effect. Used when the type is one of the periodic types:
+  /// - [`SDL_HAPTIC_SINE`]
+  /// - [`SDL_HAPTIC_TRIANGLE`]
+  /// - [`SDL_HAPTIC_SAWTOOTHDOWN`]
+  /// - [`SDL_HAPTIC_SAWTOOTHUP`]
+  pub periodic: SDL_HapticPeriodic,
+  /// Condition effect. Used when the type is one of the condition types:
+  /// - [`SDL_HAPTIC_SPRING`]
+  /// - [`SDL_HAPTIC_DAMPER`]
+  /// - [`SDL_HAPTIC_INERTIA`]
+  /// - [`SDL_HAPTIC_FRICTION`]
+  pub condition: SDL_HapticCondition,
+  /// Ramp effect. Used only when the type is [`SDL_HAPTIC_RAMP`].
+  pub ramp: SDL_HapticRamp,
+  /// Left/Right effect. Used only when the type is [`SDL_HAPTIC_LEFTRIGHT`].
+  pub leftright: SDL_HapticLeftRight,
+  /// Custom effect. Used only when the type is [`SDL_HAPTIC_CUSTOM`].
+  pub custom: SDL_HapticCustom,
+}
+
+/// Wrapper around an integer effect ID.
+///
+/// This is the type returned by uploading a [`SDL_HapticEffect`] onto a device
+/// using [`SDL_HapticNewEffect`].
+///
+/// Note: The value -1 is an invalid ID!
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(transparent)]
+pub struct SDL_HapticEffectID(pub c_int);
+
+impl SDL_HapticEffectID {
+  /// Convenience constant for the invalid haptic effect ID.
+  ///
+  /// Provided for convenience.
+  pub const INVALID: Self = Self(-1);
+  /// Returns true if this effect is valid.
+  ///
+  /// Provided for convenience.
+  #[inline]
+  pub const fn is_valid(self) -> bool {
+    self.0 != Self::INVALID.0
+  }
+  /// Returns `None` if `self` is invalid, and `Some(self)` otherwise.
+  ///
+  /// Provided for convenience.
+  #[inline]
+  pub const fn valid(self) -> Option<Self> {
+    if self.is_valid() {
+      Some(self)
+    } else {
+      None
+    }
+  }
+}
+
+extern "C" {
+  /// Count the number of haptic devices attached to the system.
+  pub fn SDL_NumHaptics() -> c_int;
+  /// Get the implementation dependent name of a haptic device.
+  ///
+  /// This can be called before any joysticks are opened. If no name can be
+  /// found, this function returns null.
+  pub fn SDL_HapticName(device_index: c_int) -> *const c_char;
+  /// Opens a haptic device for use.
+  ///
+  /// The index passed as an argument refers to the N'th haptic device on this
+  /// system.
+  ///
+  /// When opening a haptic device, its gain will be set to maximum and
+  /// autocenter will be disabled.  To modify these values use
+  /// [`SDL_HapticSetGain`] and [`SDL_HapticSetAutocenter`].
+  pub fn SDL_HapticOpen(device_index: c_int) -> *mut SDL_Haptic;
+
+  /// Checks if the haptic device at index has been opened.
+  ///
+  /// Returns 1 if it has been opened, and 0 if it has not.
+  pub fn SDL_HapticOpened(device_index: c_int) -> c_int;
+
+  /// Gets the index of a haptic device.
+  ///
+  /// Returns the index of the haptic device or -1 on error.
+  pub fn SDL_HapticIndex(haptic: *mut SDL_Haptic) -> c_int;
+
+  /// Gets whether or not the current mouse has haptic capabilities
+  ///
+  /// Returns [`SDL_TRUE`] if the mouse is haptic, [`SDL_FALSE`] if it is not.
+  pub fn SDL_MouseIsHaptic() -> c_int;
+
+  /// Tries to open a haptic device from the current mouse.
+  ///
+  /// Returns the haptic device, or NULL on error.
+  pub fn SDL_HapticOpenFromMouse() -> *mut SDL_Haptic;
+
+  /// Tries to open a haptic device from the current mouse.
+  ///
+  /// Returns 1 if the joystick is haptic, 0 if it isn't or -1 if an error
+  /// occurred.
+  pub fn SDL_JoystickIsHaptic(js: *mut SDL_Joystick) -> c_int;
+
+  /// Opens a haptic device for use from a joystick device.
+  ///
+  /// You must still close the haptic device separately.  It will not be closed
+  /// with the joystick.
+  ///
+  /// When opening from a joystick you should first close the haptic device
+  /// before closing the joystick device.  If not, on some implementations the
+  /// haptic device will also get unallocated and you'll be unable to use
+  /// force feedback on that device.
+  ///
+  /// Returns the haptic device, or NULL on error.
+  pub fn SDL_HapticOpenFromJoystick(js: *mut SDL_Joystick) -> *mut SDL_Haptic;
+
+  /// Closes a haptic device previously opened with SDL_HapticOpen().
+  pub fn SDL_HapticClose(h: *mut SDL_Haptic);
+
+  /// Returns the number of effects a haptic device can store.
+  ///
+  /// On some platforms this isn't fully supported, and therefore is an
+  /// approximation.  Always check to see if your created effect was actually
+  /// created and do not rely solely on SDL_HapticNumEffects().
+  ///
+  /// Returns the number of effects the haptic device can store or -1 on error.
+  pub fn SDL_HapticNumEffects(haptic: *mut SDL_Haptic) -> c_int;
+  /// Returns the number of effects a haptic device can play at the same time.
+  ///
+  /// This is not supported on all platforms, but will always return a value.
+  /// Added here for the sake of completeness.
+  ///
+  /// Returns The number of effects the haptic device can play at the same time
+  /// or -1 on error.
+  pub fn SDL_HapticNumEffectsPlaying(haptic: *mut SDL_Haptic) -> c_int;
+
+  /// Gets the haptic device's supported features in bitwise manner
+  ///
+  /// See also [`SDL_HapticFeatures`]
+  pub fn SDL_HapticQuery(haptic: *mut SDL_Haptic) -> SDL_HapticFeatures;
+
+  /// Gets the number of haptic axes the device has
+  pub fn SDL_HapticNumAxes(haptic: *mut SDL_Haptic) -> c_int;
+
+  /// Checks to see if effect is supported by haptic.
+  ///
+  /// Returns 1 if effect is supported, 0 if it isn't or -1 on error.
+  pub fn SDL_HapticEffectSupported(
+    haptic: *mut SDL_Haptic, effect: *mut SDL_HapticEffect,
+  ) -> c_int;
+
+  /// Creates a new haptic effect on the device.
+  ///
+  /// Returns the identifier of the effect on success or -1 on error
+  pub fn SDL_HapticNewEffect(
+    haptic: *mut SDL_Haptic, effect: *mut SDL_HapticEffect,
+  ) -> SDL_HapticEffectID;
+  /// Updates the properties of an effect.
+  ///
+  /// Can be used dynamically, although behavior when dynamically changing
+  /// direction may be strange.  Specifically the effect may reupload itself
+  /// and start playing from the start.  You cannot change the type either when
+  /// running [`SDL_HapticUpdateEffect`].
+  ///
+  /// Returns 0 on success or -1 on error.
+  pub fn SDL_HapticUpdateEffect(
+    haptic: *mut SDL_Haptic, effect: SDL_HapticEffectID,
+    data: *mut SDL_HapticEffect,
+  ) -> c_int;
+  /// Runs the haptic effect on its associated haptic device.
+  ///
+  /// If `iterations` are [`SDL_HAPTIC_INFINITY`], it'll run the effect over and
+  /// over repeating the envelope (attack and fade) every time.  If you only
+  /// want the effect to last forever, set [`SDL_HAPTIC_INFINITY`] in the
+  /// effect's length parameter.
+  ///
+  /// Returns 0 on success or -1 on error.
+  pub fn SDL_HapticRunEffect(
+    haptic: *mut SDL_Haptic, effect: SDL_HapticEffectID, iterations: Uint32,
+  ) -> c_int;
+  /// Stops the haptic effect on its associated haptic device.
+  pub fn SDL_HapticStopEffect(
+    haptic: *mut SDL_Haptic, effect: SDL_HapticEffectID,
+  ) -> c_int;
+  /// Destroys a haptic effect on the device.
+  ///
+  /// This will stop the effect if it's running.  Effects are automatically
+  /// destroyed when the device is closed.
+  pub fn SDL_HapticDestroyEffect(
+    haptic: *mut SDL_Haptic, effect: SDL_HapticEffectID,
+  );
+  /// Gets the status of the current effect on the haptic device.
+  ///
+  /// Device must support the [`SDL_HAPTIC_STATUS`] feature
+  ///
+  /// Returns 0 if it isn't playing, 1 if it is playing or -1 on error.
+  pub fn SDL_HapticGetEffectStatus(
+    haptic: *mut SDL_Haptic, effect: SDL_HapticEffectID,
+  ) -> c_int;
+  /// Sets the global gain of the device.
+  ///
+  /// `gain` should be a value beween 0 and 100.
+  ///
+  /// Device must support the [`SDL_HAPTIC_GAIN`] feature.
+  ///
+  /// The user may specify the maximum gain by setting the environment variable
+  /// `"SDL_HAPTIC_GAIN_MAX"` which should be between 0 and 100.  All calls to
+  /// `SDL_HapticSetGain` will scale linearly using SDL_HAPTIC_GAIN_MAX as the
+  /// maximum.
+  ///
+  /// Returns 0 on success or -1 on error.
+  pub fn SDL_HapticSetGain(haptic: *mut SDL_Haptic, gain: c_int) -> c_int;
+  /// Sets the global autocenter of the device.
+  ///
+  /// `autocenter` should be between 0 and 100.  Setting it to 0 will disable
+  /// autocentering.
+  ///
+  /// Device must support the [`SDL_HAPTIC_AUTOCENTER`] feature.
+  ///
+  /// The user may specify the maximum gain by setting the environment variable
+  /// `"SDL_HAPTIC_GAIN_MAX"` which should be between 0 and 100.  All calls to
+  /// `SDL_HapticSetGain` will scale linearly using SDL_HAPTIC_GAIN_MAX as the
+  /// maximum.
+  ///
+  /// Returns 0 on success or -1 on error.
+  pub fn SDL_HapticSetAutocenter(
+    haptic: *mut SDL_Haptic, autocenter: c_int,
+  ) -> c_int;
+  /// Pauses a haptic device.
+  ///
+  /// Device must support the [`SDL_HAPTIC_PAUSE`] feature.
+  ///
+  /// Call [`SDL_HapticUnpause`] to resume playback.
+  ///
+  /// Do not modify the effects nor add new ones while the device is paused.
+  /// That can cause all sorts of weird errors.
+  ///
+  /// Returns 0 on success or -1 on error.
+  pub fn SDL_HapticPause(haptic: *mut SDL_Haptic) -> c_int;
+  /// Unpauses a haptic device after pausing with [`SDL_HapticPause`].
+  ///
+  /// Returns 0 on success or -1 on error.
+  pub fn SDL_HapticUnpause(haptic: *mut SDL_Haptic) -> c_int;
+  /// Stops all the currently playing effects on a haptic device.
+  ///
+  /// Returns 0 on success or -1 on error.
+  pub fn SDL_HapticStopAll(haptic: *mut SDL_Haptic) -> c_int;
+
+  /// Checks to see if rumble is supported on a haptic device.
+  ///
+  /// Returns 1 if effect is supported, 0 if it isn't or -1 on error.
+  pub fn SDL_HapticRumbleSupported(haptic: *mut SDL_Haptic) -> c_int;
+  /// Initializes the haptic device for simple rumble playback.
+  ///
+  /// Returns 0 on success or -1 on error
+  pub fn SDL_HapticRumbleInit(haptic: *mut SDL_Haptic) -> c_int;
+  /// Runs simple rumble on a haptic device
+  ///
+  /// - `strength` should be between 0.0 and 1.0.
+  /// - `length` is in milliseconds (or [`SDL_HAPTIC_INFINITY`]).
+  ///
+  /// Returns 0 on success, or -1 on error
+  pub fn SDL_HapticRumblePlay(
+    haptic: *mut SDL_Haptic, strength: f32, length: Uint32,
+  ) -> c_int;
+  /// Stops the simple rumble on a haptic device.
+  ///
+  /// Returns 0 on success or -1 on error
+  pub fn SDL_HapticRumbleStop(haptic: *mut SDL_Haptic) -> c_int;
+}

--- a/src/joystick.rs
+++ b/src/joystick.rs
@@ -35,7 +35,6 @@ use crate::hints::*;
 use crate::*;
 
 /// The `SDL_Joystick` type is an opaque structure.
-#[derive(Debug)]
 #[repr(transparent)]
 pub struct SDL_Joystick(c_void);
 

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -17,6 +17,7 @@ pub struct SDL_Keysym {
   pub sym: SDL_Keycode,
   /// current key modifiers
   pub mod_: Uint16,
+  /// This field is apparently unused by SDL.
   pub unused: Uint32,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 #![allow(bad_style)]
 #![warn(missing_docs)]
 #![allow(clippy::missing_safety_doc)]
+#![cfg_attr(feature = "nightly_macos_link_args", feature(link_args))]
 
 //! Bindings to the SDL2 C library.
 //!
@@ -192,3 +193,18 @@ extern "C" {
   /// You should call it upon all exit conditions.
   pub fn SDL_Quit();
 }
+
+#[cfg_attr(
+  weak_framework_game_controller,
+  link_args = "-weak_framework GameController"
+)]
+#[cfg_attr(
+  weak_framework_core_haptics,
+  link_args = "-weak_framework CoreHaptics"
+)]
+#[cfg_attr(weak_framework_metal, link_args = "-weak_framework Metal")]
+#[cfg_attr(
+  weak_framework_quartz_core,
+  link_args = "-weak_framework QuartzCore"
+)]
+extern "C" {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,6 +100,7 @@ pub mod events;
 pub mod filesystem;
 pub mod gamecontroller;
 pub mod gesture;
+pub mod haptic;
 pub mod hints;
 pub mod joystick;
 pub mod keyboard;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,9 +86,7 @@ macro_rules! impl_bit_ops_for_tuple_newtype {
 
 pub mod prelude;
 
-// TODO: haptic (joystick force feedback system).
 // TODO: shape (allows shaped windows).
-// TODO: mutex (portable, no_std mutex would be handy).
 // TODO: locale (locale info)
 // TODO: misc (lets you open a browser to a URL)
 pub mod audio;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,6 +107,7 @@ pub mod keycode;
 pub mod loadso;
 pub mod messagebox;
 pub mod mouse;
+pub mod mutex;
 pub mod pixels;
 pub mod platform;
 pub mod power;

--- a/src/mutex.rs
+++ b/src/mutex.rs
@@ -1,0 +1,137 @@
+//! Portable mutexes, semaphores, and condition variables.
+use crate::{c_int, c_void};
+
+/// The SDL mutex structure. A portable mutex.
+///
+/// Rust code should treat this as opaque, and use it as `*mut SDL_mutex`
+#[repr(transparent)]
+pub struct SDL_mutex(c_void);
+
+extern "C" {
+  /// Create a mutex, initialized unlocked.
+  pub fn SDL_CreateMutex() -> *mut SDL_mutex;
+
+  /// Lock the mutex. Returns 0 or -1 on error.
+  ///
+  /// Warning: It's likely UB to lock a mutex while your thread already holds
+  /// the mutex (this is system specific).
+  pub fn SDL_LockMutex(mutex: *mut SDL_mutex) -> c_int;
+
+  /// Try to lock the mutex. Returns 0, [`SDL_MUTEX_TIMEDOUT`], or -1 on error
+  pub fn SDL_TryLockMutex(mutex: *mut SDL_mutex) -> c_int;
+
+  /// Unlock the mutex. Returns 0, or -1 on error.
+  ///
+  /// # Warning
+  /// It is an error to unlock a mutex that has not been locked by
+  /// the current thread, and doing so results in undefined behavior.
+  pub fn SDL_UnlockMutex(mutex: *mut SDL_mutex) -> c_int;
+
+  /// Destroy a mutex.
+  pub fn SDL_DestroyMutex(mutex: *mut SDL_mutex);
+}
+
+/// An alias for [`SDL_LockMutex`], for some reason.
+pub use SDL_LockMutex as SDL_mutexP;
+/// An alias for [`SDL_UnlockMutex`], for some reason.
+pub use SDL_UnlockMutex as SDL_mutexV;
+
+/// The SDL semaphore structure.
+///
+/// Rust code should treat this as opaque, and use it as `*mut SDL_sem`.
+#[repr(transparent)]
+pub struct SDL_sem(c_void);
+
+// In the C code it's `struct SDL_semaphore` but the type alias that lets you
+// use it without `struct` is `SDL_sem`. The headers use `SDL_sem`, so we will
+// too.
+
+/// Alias for [`SDL_sem`].
+pub type SDL_semaphore = SDL_sem;
+
+extern "C" {
+  /// Create a semaphore, initialized with value, returns null on failure.
+  pub fn SDL_CreateSemaphore(initial_value: u32) -> *mut SDL_sem;
+
+  /// Destroy a semaphore.
+  pub fn SDL_DestroySemaphore(sem: *mut SDL_sem);
+
+  /// This function suspends the calling thread until the semaphore pointed
+  /// to by `sem` has a positive count. It then atomically decreases the
+  /// semaphore count.
+  pub fn SDL_SemWait(sem: *mut SDL_sem) -> c_int;
+
+  /// Non-blocking variant of [`SDL_SemWait`].
+  ///
+  /// return 0 if the wait succeeds, [`SDL_MUTEX_TIMEDOUT`] if the wait would
+  /// block, and -1 on error.
+  pub fn SDL_SemTryWait(sem: *mut SDL_sem) -> c_int;
+
+  /// Variant of [`SDL_SemWait`] with a timeout in milliseconds.
+  ///
+  /// Returns 0 if the wait succeeds, [`SDL_MUTEX_TIMEDOUT`] if the wait does
+  /// not succeed in the allotted time, and -1 on error.
+  ///
+  /// # Warning
+  /// On some platforms this function is implemented by looping with a
+  /// delay of 1 ms, and so should be avoided if possible.
+  pub fn SDL_SemWaitTimeout(sem: *mut SDL_sem, ms: c_int) -> c_int;
+
+  /// Atomically increases the semaphore's count (not blocking).
+  /// Returns 0, or -1 on error.
+  pub fn SDL_SemPost(sem: *mut SDL_sem) -> c_int;
+
+  /// Returns the current count of the semaphore.
+  pub fn SDL_SemValue(sem: *mut SDL_sem) -> u32;
+}
+
+/// The SDL condition variable structure.
+///
+/// Rust code should treat this as opaque, and use it as `*mut SDL_cond`.
+#[repr(transparent)]
+pub struct SDL_cond(c_void);
+
+extern "C" {
+  /// Create a condition variable.
+  pub fn SDL_CreateCond() -> *mut SDL_cond;
+
+  /// Destroy a condition variable.
+  pub fn SDL_DestroyCond(cond: *mut SDL_cond);
+  /// Restart one of the threads that are waiting on the condition variable.
+  ///
+  /// Returns 0 or -1 on error.
+  pub fn SDL_CondSignal(cond: *mut SDL_cond) -> c_int;
+
+  /// Restart all threads that are waiting on the condition variable.
+  ///
+  /// Returns 0 or -1 on error.
+  pub fn SDL_CondBroadcast(cond: *mut SDL_cond) -> c_int;
+
+  /// Wait on the condition variable, unlocking the provided mutex.
+  ///
+  /// Returns 0 when it is signaled, or -1 on error.
+  ///
+  /// # Warning
+  /// The mutex must be locked before entering this function!
+  ///
+  /// The mutex is re-locked once the condition variable is signaled.
+  pub fn SDL_CondWait(cond: *mut SDL_cond, mutex: *mut SDL_mutex) -> c_int;
+
+  /// Waits for at most `ms` milliseconds, and returns 0 if the condition
+  /// variable is signaled, `SDL_MUTEX_TIMEDOUT` if the condition is not
+  /// signaled in the allotted time, and -1 on error.
+  ///
+  /// # Warning
+  /// On some platforms this function is implemented by looping with a
+  /// delay of 1 ms, and so should be avoided if possible.
+  pub fn SDL_CondWaitTimeout(
+    cond: *mut SDL_cond, mutex: *mut SDL_mutex, ms: u32,
+  ) -> c_int;
+}
+
+/// Synchronization functions which can time out return this value
+/// if they time out.
+pub const SDL_MUTEX_TIMEDOUT: c_int = 1;
+
+/// This is the timeout value which corresponds to never time out.
+pub const SDL_MUTEX_MAXWAIT: u32 = !0u32;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -9,7 +9,7 @@ pub use crate::{
   audio::*, blendmode::*, c_char, c_double, c_float, c_int, c_long, c_longlong,
   c_schar, c_short, c_uchar, c_uint, c_ulong, c_ulonglong, c_ushort, c_void,
   clipboard::*, cpuinfo::*, error::*, events::*, filesystem::*,
-  gamecontroller::*, gesture::*, hints::*, joystick::*, keyboard::*,
+  gamecontroller::*, gesture::*, haptic::*, hints::*, joystick::*, keyboard::*,
   keycode::*, loadso::*, messagebox::*, mouse::*, mutex::*, pixels::*,
   platform::*, power::*, quit::*, rect::*, renderer::*, rwops::*, scancode::*,
   sensor::*, stdinc::*, surface::*, syswm::*, timer::*, touch::*, version::*,

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -10,8 +10,8 @@ pub use crate::{
   c_schar, c_short, c_uchar, c_uint, c_ulong, c_ulonglong, c_ushort, c_void,
   clipboard::*, cpuinfo::*, error::*, events::*, filesystem::*,
   gamecontroller::*, gesture::*, hints::*, joystick::*, keyboard::*,
-  keycode::*, loadso::*, messagebox::*, mouse::*, pixels::*, platform::*,
-  power::*, quit::*, rect::*, renderer::*, rwops::*, scancode::*, sensor::*,
-  stdinc::*, surface::*, syswm::*, timer::*, touch::*, version::*, video::*,
-  vulkan::*, *,
+  keycode::*, loadso::*, messagebox::*, mouse::*, mutex::*, pixels::*,
+  platform::*, power::*, quit::*, rect::*, renderer::*, rwops::*, scancode::*,
+  sensor::*, stdinc::*, surface::*, syswm::*, timer::*, touch::*, version::*,
+  video::*, vulkan::*, *,
 };


### PR DESCRIPTION
- Add mutex.rs (old)
- fix warnings on macos
- Remove `#[derive(Debug)]` from types that are `c_void` wrappers (if it ever ran it would be unsound, since it would read a byte out of an opaque type
- Add haptic.rs
- Massive (still in-progress) rewrite of build.rs

Draft PR since I still need more build.rs changes, and they're only smoke-tested, and entirely untested on windows.