### PR TITLE
Fix build failures when vulkan feature is disabled

### DIFF
--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -12,6 +12,8 @@ pub use crate::{
   gamecontroller::*, gesture::*, hints::*, joystick::*, keyboard::*,
   keycode::*, loadso::*, messagebox::*, mouse::*, pixels::*, platform::*,
   power::*, quit::*, rect::*, renderer::*, rwops::*, scancode::*, sensor::*,
-  stdinc::*, surface::*, syswm::*, timer::*, touch::*, version::*, video::*,
-  vulkan::*, *,
+  stdinc::*, surface::*, syswm::*, timer::*, touch::*, version::*, video::*, *,
 };
+
+#[cfg(feature = "vulkan")]
+pub use crate::vulkan::*;

--- a/src/video.rs
+++ b/src/video.rs
@@ -6,6 +6,7 @@ use crate::{c_char, c_int, c_void, rect::*, stdinc::*, surface::*};
 #[allow(unused)]
 use crate::error::*;
 #[allow(unused)]
+#[cfg(feature = "vulkan")]
 use crate::vulkan::*;
 
 /// The structure that defines a display mode


### PR DESCRIPTION
With the latest version of Fermium, if you set `default-features = false`, the build fails due to some missing imports:

```rust
   Compiling fermium v22604.0.0
error[E0432]: unresolved import `crate::vulkan`
  --> E:\Rust\.cargo\registry\src\github.com-1ecc6299db9ec823\fermium-22604.0.0\src\prelude.rs:16:3
   |
16 |   vulkan::*, *,
   |   ^^^^^^ could not find `vulkan` in the crate root

error[E0432]: unresolved import `crate::vulkan`
 --> E:\Rust\.cargo\registry\src\github.com-1ecc6299db9ec823\fermium-22604.0.0\src\video.rs:9:12
  |
9 | use crate::vulkan::*;
  |            ^^^^^^ could not find `vulkan` in the crate root

For more information about this error, try `rustc --explain E0432`.
error: could not compile `fermium` due to 2 previous errors
```

This PR fixes that.

Wasn't entirely sure how best to format the change to the prelude, let me know if it needs tweaking!

(also thank you for fermium, it feels a lot nicer to use than sdl2-rs so far)

